### PR TITLE
update: fix link to drgtk docs spritesheet section

### DIFF
--- a/src/10-animation.md
+++ b/src/10-animation.md
@@ -23,7 +23,7 @@ Then we take the `player_sprite_index` and use that when specifying the `path` o
 
 ## A Note on Spritesheets
 
-If you've done any game development before, you may be familiar with spritesheets, where each frame of an animation is contained within one image file. When using a spritesheet for animation, instead of changing which image file path is used for the sprite to render, you change which piece of the large spritesheet you render. [The DragonRuby GTK docs have a detailed example of how to do this.](http://docs.dragonruby.org.s3-website-us-east-1.amazonaws.com/#----animation-using-sprite-sheet---main-rb)
+If you've done any game development before, you may be familiar with spritesheets, where each frame of an animation is contained within one image file. When using a spritesheet for animation, instead of changing which image file path is used for the sprite to render, you change which piece of the large spritesheet you render. [The DragonRuby GTK docs have a detailed example of how to do this.](http://docs.dragonruby.org/#----animation-using-sprite-sheet---main-rb)
 
 ## Extra Credit
 

--- a/src/10-animation.md
+++ b/src/10-animation.md
@@ -23,7 +23,7 @@ Then we take the `player_sprite_index` and use that when specifying the `path` o
 
 ## A Note on Spritesheets
 
-If you've done any game development before, you may be familiar with spritesheets, where each frame of an animation is contained within one image file. When using a spritesheet for animation, instead of changing which image file path is used for the sprite to render, you change which piece of the large spritesheet you render. [The DragonRuby GTK docs have a detailed example of how to do this.](https://bit.ly/drgtk-spritesheet)
+If you've done any game development before, you may be familiar with spritesheets, where each frame of an animation is contained within one image file. When using a spritesheet for animation, instead of changing which image file path is used for the sprite to render, you change which piece of the large spritesheet you render. [The DragonRuby GTK docs have a detailed example of how to do this.](http://docs.dragonruby.org.s3-website-us-east-1.amazonaws.com/#----animation-using-sprite-sheet---main-rb)
 
 ## Extra Credit
 


### PR DESCRIPTION
The sprite sheet animation bit.ly link in Ch. 10 points to what seems to be an old section link of the DRGTK docs which no longer exists and resolves to the 'Welcome' section. This PR implements the current link to the appropriate DRGTK docs section.